### PR TITLE
fake out /proc/version

### DIFF
--- a/assets/all/assets.txt
+++ b/assets/all/assets.txt
@@ -1,4 +1,4 @@
-execInProot.sh 1542665446
+execInProot.sh 1542668592
 isServerInProcTree.sh 1537176474
 killProcTree.sh 1532381687
 stat4 1537480463

--- a/assets/all/assets.txt
+++ b/assets/all/assets.txt
@@ -1,4 +1,4 @@
-execInProot.sh 1537480463
+execInProot.sh 1542660509
 isServerInProcTree.sh 1537176474
 killProcTree.sh 1532381687
 stat4 1537480463

--- a/assets/all/assets.txt
+++ b/assets/all/assets.txt
@@ -1,4 +1,4 @@
-execInProot.sh 1542660509
+execInProot.sh 1542665269
 isServerInProcTree.sh 1537176474
 killProcTree.sh 1532381687
 stat4 1537480463

--- a/assets/all/assets.txt
+++ b/assets/all/assets.txt
@@ -1,4 +1,4 @@
-execInProot.sh 1542665269
+execInProot.sh 1542665446
 isServerInProcTree.sh 1537176474
 killProcTree.sh 1532381687
 stat4 1537480463

--- a/assets/all/execInProot.sh
+++ b/assets/all/execInProot.sh
@@ -21,7 +21,7 @@ if [[ ! -r /proc/uptime ]] ; then
 	EXTRA_BINDINGS="$EXTRA_BINDINGS -b $ROOT_PATH/support/uptime:/proc/uptime" 
 fi
 if [[ ! -r /proc/version ]] ; then
-	if [[ ! -r $ROOT_PATH/support/version ]] ; then
+	if [[ ! -f $ROOT_PATH/support/version ]] ; then
 		currDate="$($ROOT_PATH/support/busybox date)"
 		echo "Linux version $OS_VERSION (fake@userland) #1 $currDate" > $ROOT_PATH/support/version
 		EXTRA_BINDINGS="$EXTRA_BINDINGS -b $ROOT_PATH/support/version:/proc/version" 

--- a/assets/all/execInProot.sh
+++ b/assets/all/execInProot.sh
@@ -2,6 +2,10 @@
 
 $ROOT_PATH/support/busybox clear
 
+if [[ -z "${OS_VERSION}" ]]; then
+  OS_VERSION="4.0.0"
+fi
+
 if [[ ! -r /dev/ashmem ]] ; then
 	EXTRA_BINDINGS="$EXTRA_BINDINGS -b $ROOTFS_PATH/tmp:/dev/ashmem" 
 fi

--- a/assets/all/execInProot.sh
+++ b/assets/all/execInProot.sh
@@ -21,11 +21,9 @@ if [[ ! -r /proc/uptime ]] ; then
 	EXTRA_BINDINGS="$EXTRA_BINDINGS -b $ROOT_PATH/support/uptime:/proc/uptime" 
 fi
 if [[ ! -r /proc/version ]] ; then
-	if [[ ! -f $ROOT_PATH/support/version ]] ; then
-		currDate="$($ROOT_PATH/support/busybox date)"
-		echo "Linux version $OS_VERSION (fake@userland) #1 $currDate" > $ROOT_PATH/support/version
-		EXTRA_BINDINGS="$EXTRA_BINDINGS -b $ROOT_PATH/support/version:/proc/version" 
-	fi
+	currDate="$($ROOT_PATH/support/busybox date)"
+	echo "Linux version $OS_VERSION (fake@userland) #1 $currDate" > $ROOT_PATH/support/version
+	EXTRA_BINDINGS="$EXTRA_BINDINGS -b $ROOT_PATH/support/version:/proc/version" 
 fi
 
 #launch PRoot

--- a/assets/all/execInProot.sh
+++ b/assets/all/execInProot.sh
@@ -20,6 +20,13 @@ fi
 if [[ ! -r /proc/uptime ]] ; then
 	EXTRA_BINDINGS="$EXTRA_BINDINGS -b $ROOT_PATH/support/uptime:/proc/uptime" 
 fi
+if [[ ! -r /proc/version ]] ; then
+	if [[ ! -r $ROOT_PATH/support/version ]] ; then
+		currDate="$($ROOT_PATH/support/busybox date)"
+		echo "Linux version $OS_VERSION (fake@userland) #1 $currDate" > $ROOT_PATH/support/version
+		EXTRA_BINDINGS="$EXTRA_BINDINGS -b $ROOT_PATH/support/version:/proc/version" 
+	fi
+fi
 
 #launch PRoot
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PROOT_TMP_DIR=$ROOTFS_PATH/support/ $ROOT_PATH/support/proot -r $ROOTFS_PATH -v $PROOT_DEBUG_LEVEL -p -H -0 -l -L -b /sys -b /dev -b /proc -b /data -b /mnt -b /proc/mounts:/etc/mtab -b /:/host-rootfs -b $ROOTFS_PATH/support/:/support -b $ROOTFS_PATH/support/nosudo:/usr/local/bin/sudo -b $ROOTFS_PATH/support/userland_profile.sh:/etc/profile.d/userland_profile.sh -b $ROOTFS_PATH/support/ld.so.preload:/etc/ld.so.preload $EXTRA_BINDINGS $@


### PR DESCRIPTION
Sometimes /proc/version is not readable, so we recreate it and bind it when needed.  