### PR TITLE
Add App Signal

### DIFF
--- a/apps/apps.txt
+++ b/apps/apps.txt
@@ -17,3 +17,4 @@ Gimp, Office, debian, false, true, false, 1
 Inkscape, Office, debian, false, true, false, 1
 Git, Development, debian, false, true, false, 1
 Idle, Development, debian, false, true, false, 1
+Signal, Chat, debian, false, true, false, 1


### PR DESCRIPTION
Add Signal Messanger Desktop App.
It's usefull for Android Tablets, because Signal does not Support multiple Android Devices for one User.
With the Signal Linux Desktop App you can use signal on your Tablet as an secondary Device.